### PR TITLE
Ability to force warped time / Disallow pre-genesis time travel

### DIFF
--- a/es6/main.js
+++ b/es6/main.js
@@ -55,6 +55,9 @@ class AnimationsHandler {
         // console.log('RUNNING ANIMATION DISPATCHER')
         const {animations} = this.store.getState()
         this.time.setSpeed(animations.speed)
+        if (true === animations.force) {
+          this.time.setWarpedTime(animations.warped_time)
+        }
         const timestamp = this.time.getWarpedTime()
         if (!this.animating && shouldAnimate(animations.queue, timestamp, this.time.speed)) {
             if (global.DEBUG) {
@@ -69,7 +72,12 @@ class AnimationsHandler {
     tick(high_res_timestamp) {
         this.animating = true
         const {animations} = this.store.getState()
-        const new_timestamp = this.time.getWarpedTime()
+        let new_timestamp = this.time.getWarpedTime()
+
+        if(new_timestamp < this.time.genesis_time) {
+          new_timestamp = this.time.genesis_time;
+          animations.speed = 0
+        }
 
         if (shouldAnimate(animations.queue, new_timestamp, animations.speed)) {
             global.nextFrameId = this.requestFrame(::this.tick)

--- a/es6/reducers.js
+++ b/es6/reducers.js
@@ -117,9 +117,10 @@ export const animationsReducer = (state=initial_state, action) => {
             return {
                 ...state,
                 state: animated_state,
-                speed: action.speed || state.speed,
+                speed: (action.speed || (!state.speed && state.speed)) + 0,
                 warped_time: action.warped_time,
                 former_time: action.former_time,
+                force: action.force,
             }
 
         default:

--- a/examples/static/ball.js
+++ b/examples/static/ball.js
@@ -1128,6 +1128,9 @@ var AnimationsHandler = function () {
                 animations = _store$getState.animations;
 
             this.time.setSpeed(animations.speed);
+            if (true === animations.force) {
+                this.time.setWarpedTime(animations.warped_time);
+            }
             var timestamp = this.time.getWarpedTime();
             if (!this.animating && shouldAnimate(animations.queue, timestamp, this.time.speed)) {
                 if (global.DEBUG) {
@@ -1145,6 +1148,11 @@ var AnimationsHandler = function () {
                 animations = _store$getState2.animations;
 
             var new_timestamp = this.time.getWarpedTime();
+
+            if (new_timestamp < this.time.genesis_time) {
+                new_timestamp = this.time.genesis_time;
+                animations.speed = 0;
+            }
 
             if (shouldAnimate(animations.queue, new_timestamp, animations.speed)) {
                 global.nextFrameId = this.requestFrame(this.tick.bind(this));
@@ -1302,9 +1310,10 @@ var animationsReducer = exports.animationsReducer = function animationsReducer()
 
             return (0, _extends3.default)({}, state, {
                 state: animated_state,
-                speed: action.speed || state.speed,
+                speed: (action.speed || !state.speed && state.speed) + 0,
                 warped_time: action.warped_time,
-                former_time: action.former_time
+                former_time: action.former_time,
+                force: action.force
             });
 
         default:

--- a/examples/static/demo.js
+++ b/examples/static/demo.js
@@ -1189,6 +1189,9 @@ var AnimationsHandler = function () {
                 animations = _store$getState.animations;
 
             this.time.setSpeed(animations.speed);
+            if (true === animations.force) {
+                this.time.setWarpedTime(animations.warped_time);
+            }
             var timestamp = this.time.getWarpedTime();
             if (!this.animating && shouldAnimate(animations.queue, timestamp, this.time.speed)) {
                 if (global.DEBUG) {
@@ -1206,6 +1209,11 @@ var AnimationsHandler = function () {
                 animations = _store$getState2.animations;
 
             var new_timestamp = this.time.getWarpedTime();
+
+            if (new_timestamp < this.time.genesis_time) {
+                new_timestamp = this.time.genesis_time;
+                animations.speed = 0;
+            }
 
             if (shouldAnimate(animations.queue, new_timestamp, animations.speed)) {
                 global.nextFrameId = this.requestFrame(this.tick.bind(this));
@@ -1363,9 +1371,10 @@ var animationsReducer = exports.animationsReducer = function animationsReducer()
 
             return (0, _extends3.default)({}, state, {
                 state: animated_state,
-                speed: action.speed || state.speed,
+                speed: (action.speed || !state.speed && state.speed) + 0,
                 warped_time: action.warped_time,
-                former_time: action.former_time
+                former_time: action.former_time,
+                force: action.force
             });
 
         default:

--- a/examples/static/stress-test.js
+++ b/examples/static/stress-test.js
@@ -1077,6 +1077,9 @@ var AnimationsHandler = function () {
                 animations = _store$getState.animations;
 
             this.time.setSpeed(animations.speed);
+            if (true === animations.force) {
+                this.time.setWarpedTime(animations.warped_time);
+            }
             var timestamp = this.time.getWarpedTime();
             if (!this.animating && shouldAnimate(animations.queue, timestamp, this.time.speed)) {
                 if (global.DEBUG) {
@@ -1094,6 +1097,11 @@ var AnimationsHandler = function () {
                 animations = _store$getState2.animations;
 
             var new_timestamp = this.time.getWarpedTime();
+
+            if (new_timestamp < this.time.genesis_time) {
+                new_timestamp = this.time.genesis_time;
+                animations.speed = 0;
+            }
 
             if (shouldAnimate(animations.queue, new_timestamp, animations.speed)) {
                 global.nextFrameId = this.requestFrame(this.tick.bind(this));
@@ -1251,9 +1259,10 @@ var animationsReducer = exports.animationsReducer = function animationsReducer()
 
             return (0, _extends3.default)({}, state, {
                 state: animated_state,
-                speed: action.speed || state.speed,
+                speed: (action.speed || !state.speed && state.speed) + 0,
                 warped_time: action.warped_time,
-                former_time: action.former_time
+                former_time: action.former_time,
+                force: action.force
             });
 
         default:

--- a/examples/static/threejs.js
+++ b/examples/static/threejs.js
@@ -1035,6 +1035,9 @@ var AnimationsHandler = function () {
                 animations = _store$getState.animations;
 
             this.time.setSpeed(animations.speed);
+            if (true === animations.force) {
+                this.time.setWarpedTime(animations.warped_time);
+            }
             var timestamp = this.time.getWarpedTime();
             if (!this.animating && shouldAnimate(animations.queue, timestamp, this.time.speed)) {
                 if (global.DEBUG) {
@@ -1052,6 +1055,11 @@ var AnimationsHandler = function () {
                 animations = _store$getState2.animations;
 
             var new_timestamp = this.time.getWarpedTime();
+
+            if (new_timestamp < this.time.genesis_time) {
+                new_timestamp = this.time.genesis_time;
+                animations.speed = 0;
+            }
 
             if (shouldAnimate(animations.queue, new_timestamp, animations.speed)) {
                 global.nextFrameId = this.requestFrame(this.tick.bind(this));
@@ -1209,9 +1217,10 @@ var animationsReducer = exports.animationsReducer = function animationsReducer()
 
             return (0, _extends3.default)({}, state, {
                 state: animated_state,
-                speed: action.speed || state.speed,
+                speed: (action.speed || !state.speed && state.speed) + 0,
                 warped_time: action.warped_time,
-                former_time: action.former_time
+                former_time: action.former_time,
+                force: action.force
             });
 
         default:

--- a/node/main.js
+++ b/node/main.js
@@ -92,6 +92,9 @@ var AnimationsHandler = function () {
                 animations = _store$getState.animations;
 
             this.time.setSpeed(animations.speed);
+            if (true === animations.force) {
+                this.time.setWarpedTime(animations.warped_time);
+            }
             var timestamp = this.time.getWarpedTime();
             if (!this.animating && shouldAnimate(animations.queue, timestamp, this.time.speed)) {
                 if (global.DEBUG) {
@@ -109,6 +112,11 @@ var AnimationsHandler = function () {
                 animations = _store$getState2.animations;
 
             var new_timestamp = this.time.getWarpedTime();
+
+            if (new_timestamp < this.time.genesis_time) {
+                new_timestamp = this.time.genesis_time;
+                animations.speed = 0;
+            }
 
             if (shouldAnimate(animations.queue, new_timestamp, animations.speed)) {
                 global.nextFrameId = this.requestFrame(this.tick.bind(this));

--- a/node/reducers.js
+++ b/node/reducers.js
@@ -116,9 +116,10 @@ var animationsReducer = exports.animationsReducer = function animationsReducer()
 
             return (0, _extends3.default)({}, state, {
                 state: animated_state,
-                speed: action.speed || state.speed,
+                speed: (action.speed || !state.speed && state.speed) + 0,
                 warped_time: action.warped_time,
-                former_time: action.former_time
+                former_time: action.former_time,
+                force: action.force
             });
 
         default:


### PR DESCRIPTION
Makes it possible to set the warped time (force) and by doing so allows to play from a given time (which in turn,  for instance, allows to play from the past).

Also disallow to travel before the genesis time.